### PR TITLE
refactor: add project list as a reusable component

### DIFF
--- a/demos/keeptrack/src/projects/ProjectList.tsx
+++ b/demos/keeptrack/src/projects/ProjectList.tsx
@@ -1,0 +1,11 @@
+import { Project } from './Project';
+
+interface ProjectListProps {
+  projects: Project[];
+}
+
+function ProjectList({ projects }: ProjectListProps) {
+  return <pre>{JSON.stringify(projects, null, ' ')}</pre>;
+}
+
+export default ProjectList;

--- a/demos/keeptrack/src/projects/ProjectsPage.tsx
+++ b/demos/keeptrack/src/projects/ProjectsPage.tsx
@@ -1,10 +1,11 @@
 import { MOCK_PROJECTS } from "./MockProjects";
+import ProjectList from './ProjectList';
 
 function ProjectsPage(){
     return (
         <>
             <h1>Projects</h1>
-            <pre>{JSON.stringify(MOCK_PROJECTS, null, ' ')}</pre>
+            <ProjectList projects={MOCK_PROJECTS} />
         </>
     );
 }


### PR DESCRIPTION
Following the series, lab6: https://handsonreact.com/docs/labs/ts/06-PassingDataToComponent